### PR TITLE
Update redis-cart.yaml

### DIFF
--- a/deploy/redis-cart.yaml
+++ b/deploy/redis-cart.yaml
@@ -11,8 +11,6 @@ spec:
       labels:
         app: redis-cart
     spec:
-      nodeSelector:
-        kubernetes.io/hostname: test-worker-2
       containers:
       - name: redis
         image: redis:alpine


### PR DESCRIPTION
there is no need of node selector , as we only have two nodes , so its been removed